### PR TITLE
fix(Multi): promisify exec_transaction and fix typeof

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,8 @@ for (const k of require('./cmds.json')) {
 }
 
 const multi = redis.Multi.prototype;
-for (const k of ['exec', 'exec_atomic']) if (typeof multi[k] === 'functin') multi[k] = promisify(multi[k]);
+for (const k of ['exec', 'exec_atomic', 'exec_transaction']) {
+  if (typeof multi[k] === 'function') multi[k] = promisify(multi[k]);
+}
 
 module.exports = redis;


### PR DESCRIPTION
Two small things:
- Fixed a typo in the typeof for Multi: `functin` -> `function`
- And promisified `Multi#exec_transaction`.
`Redis#multi` overrides `Multi#exec` with that method for some reason.
See [source](https://github.com/NodeRedis/node_redis/blob/master/lib/individualCommands.js#L26).